### PR TITLE
Update default yts api url

### DIFF
--- a/src/app/lib/views/settings_container.js
+++ b/src/app/lib/views/settings_container.js
@@ -129,7 +129,7 @@
 
 	resetMovieAPI: function () {
             var value = [{
-                url: 'http://yify.is/index.php/',
+                url: 'http://yify.is/',
                 strictSSL: true
             }, {
                 url: 'https://yts.ag/',

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -104,7 +104,7 @@ Settings.tvAPI = [{
 }];
 
 Settings.ytsAPI = [{
-    url: 'http://yify.is/index.php/',
+    url: 'http://yify.is/',
     strictSSL: true
 },{
     url: 'https://yts.ag/',


### PR DESCRIPTION
The current default url of http://yify.is/index.php was causing of not being able to access the movie detail page after a search. The updated url (http://yify.is/) works as normal after a search.